### PR TITLE
Proposed change on outdated ami column names

### DIFF
--- a/metrics/aws_outdated_amis/schemas/aws_outdated_amis.sql
+++ b/metrics/aws_outdated_amis/schemas/aws_outdated_amis.sql
@@ -1,14 +1,14 @@
 CREATE EXTERNAL TABLE IF NOT EXISTS aws_outdated_amis (
   `account` STRING,
-  `aminame` STRING,
-  `app` STRING,
+  `ami_name` STRING,
+  `instance_app` STRING,
   `day` STRING,
-  `name` STRING,
-  `owner` STRING,
-  `stack` STRING,
+  `instance_name` STRING,
+  `instance_owner` STRING,
+  `instance_stack` STRING,
   `status` STRING,
   `test_name` STRING,
-  `type` STRING,
+  `instance_type` STRING,
   `value` STRING
 )
 ROW FORMAT  serde 'org.openx.data.jsonserde.JsonSerDe'

--- a/metrics/aws_outdated_amis/transformers/aws_outdated_amis.py
+++ b/metrics/aws_outdated_amis/transformers/aws_outdated_amis.py
@@ -38,7 +38,7 @@ def handle_day_files(src_dir, dest_dir, day_str):
               resDict = {}
               resDict['day'] = day_str;
               resDict['account'] = account
-              resDict['name'] = res['name']
+              resDict['ami_name'] = res['metadata']['ImageId']
               resDict['test_name'] = res['test_name']
               resDict['status'] = res['status']
               resDict['value'] = res['value']
@@ -47,11 +47,11 @@ def handle_day_files(src_dir, dest_dir, day_str):
               for tagpair in res['metadata']['Tags']:
                 tags[tagpair['Key']] = tagpair['Value']
 
-              resDict['aminame'] = optional(tags, 'Name')
-              resDict['owner'] = optional(tags, 'Owner')
-              resDict['stack'] = optional(tags, 'Stack')
-              resDict['type'] = optional(tags, 'Type')
-              resDict['app'] = optional(tags, 'App')
+              resDict['instance_name'] = optional(tags, 'Name')
+              resDict['instance_owner'] = optional(tags, 'Owner')
+              resDict['instance_stack'] = optional(tags, 'Stack')
+              resDict['instance_type'] = optional(tags, 'Type')
+              resDict['instance_app'] = optional(tags, 'App')
     
               output_file.write(json.dumps(resDict) + '\n')
         


### PR DESCRIPTION
I'm unsure of the current migration process, and feel free to veto these column names, but I think these might be more clear for those viewing this table.

As well, requires https://github.com/mozilla-services/pytest-services/pull/155 which adds the actual current image id to the results.