### PR TITLE
Make ami_name optional to cope with historic data

### DIFF
--- a/metrics/aws_outdated_amis/transformers/aws_outdated_amis.py
+++ b/metrics/aws_outdated_amis/transformers/aws_outdated_amis.py
@@ -38,7 +38,7 @@ def handle_day_files(src_dir, dest_dir, day_str):
               resDict = {}
               resDict['day'] = day_str;
               resDict['account'] = account
-              resDict['ami_name'] = res['metadata']['ImageId']
+              resDict['ami_name'] = optional(res['metadata'], 'ImageId')
               resDict['test_name'] = res['test_name']
               resDict['status'] = res['status']
               resDict['value'] = res['value']


### PR DESCRIPTION
cc @ajvb - backwards compatibility is good in case we need to regenerate everything