### PR TITLE
Use boto3 credentials support in cfs.py

### DIFF
--- a/utils/cfs.py
+++ b/utils/cfs.py
@@ -6,7 +6,6 @@ Currently only S3 is supported.
 
 import argparse
 import boto3
-import os
 
 def upload_file(locfile, desttype, destloc, destname):
     """
@@ -19,9 +18,7 @@ def upload_file(locfile, desttype, destloc, destname):
         destname (str):   The destination name, for s3 this may include a path
     """
     if desttype == 's3':
-        s3 = boto3.client('s3',
-                          aws_access_key_id=os.environ['AWS_ACCESS_KEY'],
-                          aws_secret_access_key=os.environ['AWS_SECRET_KEY'],)
+        s3 = boto3.client('s3')
         s3.upload_file(locfile, destloc, destname)
     else:
         raise ValueError('Destination type not supported, currently only s3 is supported.')
@@ -37,9 +34,7 @@ def download_file(locfile, srctype, srcloc, srcname):
         srcname (str):    The source name, for s3 this may include a path
     """
     if srctype == 's3':
-        s3 = boto3.client('s3',
-                          aws_access_key_id=os.environ['AWS_ACCESS_KEY'],
-                          aws_secret_access_key=os.environ['AWS_SECRET_KEY'],)
+        s3 = boto3.client('s3')
         s3.download_file(srcloc, srcname, locfile)
     else:
         raise ValueError('Source type not supported, currently only s3 is supported.')


### PR DESCRIPTION
boto3 supports all mechanisms for supplying AWS credentials:
  https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#configuring-credentials

Removing the hardcoding will allow for a user to use either env vars,
a `.aws/credentials` file, or the role assigned to the ec2 instance
(e.g. while running jobs in Jenkins).

I am making this change so that I can use `cfs.py` within the pytest-services
jobs, where I am relying on the Jenkin worker's IAM Role.

**Note:** Before merging this, make sure all automation is using `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` instead of the original env vars.