### PR TITLE
Only extract tags if they exist

### DIFF
--- a/metrics/aws_outdated_amis/transformers/aws_outdated_amis.py
+++ b/metrics/aws_outdated_amis/transformers/aws_outdated_amis.py
@@ -42,10 +42,12 @@ def handle_day_files(src_dir, dest_dir, day_str):
               resDict['test_name'] = res['test_name']
               resDict['status'] = res['status']
               resDict['value'] = res['value']
+
               # Extract all of the metadata tags
               tags = {}
-              for tagpair in res['metadata']['Tags']:
-                tags[tagpair['Key']] = tagpair['Value']
+              if res['metadata'].get('Tags') is not None:
+                  for tagpair in res['metadata']['Tags']:
+                    tags[tagpair['Key']] = tagpair['Value']
 
               resDict['instance_name'] = optional(tags, 'Name')
               resDict['instance_owner'] = optional(tags, 'Owner')


### PR DESCRIPTION
Currently getting this error in jenkins:
```
Traceback (most recent call last):
  File "./aws_outdated_amis.py", line 99, in <module>
    main()
  File "./aws_outdated_amis.py", line 93, in main
    handle_day_files(args.source_dir, args.dest_dir, args.day)
  File "./aws_outdated_amis.py", line 47, in handle_day_files
    for tagpair in res['metadata']['Tags']:
KeyError: 'Tags'
```

Once this is landed, this should be re-ran for the last few days.