### PR TITLE
Error out on script failure

### DIFF
--- a/metrics/aws_outdated_amis/transformers/aws_outdated_amis_wrapper.sh
+++ b/metrics/aws_outdated_amis/transformers/aws_outdated_amis_wrapper.sh
@@ -1,3 +1,7 @@
+#!/bin/bash
+
+set -e
+
 # Wrapper for running the main aws_outdated_amis transformer
 
 # Install aws_cli

--- a/metrics/aws_pytest/transformers/aws_pytest_wrapper.sh
+++ b/metrics/aws_pytest/transformers/aws_pytest_wrapper.sh
@@ -1,3 +1,7 @@
+#!/bin/bash
+
+set -e
+
 # Wrapper for running the main aws_pytest transformer
 
 # Install aws_cli


### PR DESCRIPTION
Related to https://github.com/mozilla-services/foxsec-tools/pull/71

This will cause the Jenkins job (or any runner) to error out if any line in the script fails.