### PR TITLE
Add export_athena to backup Athena views

### DIFF
--- a/metrics/utils/README.md
+++ b/metrics/utils/README.md
@@ -3,6 +3,20 @@
 Utilities in this directory are most likely only needed by the metrics
 product.
 
+## export_athena - Export Athena view definitions as SQL
+
+This tool is used to obtain local copies of the queries, which can then
+be added to the git repository. Typical usage:
+```bash
+    cd ../views/
+    ../utils/export_athena
+    # runs
+    git status .
+    # add any new *.sql files
+    git commit -am "Backup"
+    git push
+```
+
 ## gen_athena_ddl - Generate Athena compatible DDL from JSON files
 
 This tool is used to generate DDL from a collection of sample JSON

--- a/metrics/utils/export_athena
+++ b/metrics/utils/export_athena
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -eu
+USAGE="usage: ${0##*/} [options]
+Copy down all Athena Queries, saving as {table-name}.sql
+
+Options:
+    -h | --help     display this help and exit"
+
+warn() { for m ; do echo "$m"; done 1>&2 ; }
+die() { warn "$@" ; exit 2; }
+usage() { warn "$@" "$USAGE"; test $# -eq 0; exit $?; }
+
+# defaults
+export AWS_DEFAULT_PROFILE=cloudservices-aws-stage
+export AWS_DEFAULT_REGION=us-east-1
+DATABASE=foxsec_metrics
+S3=s3://hwine-test-stage/athena/output/
+
+while test $# -gt 0; do
+    case "$1" in
+        -h|--help) usage ;;
+        -*) usage "Unknown option '$1'" ;;
+        *) break ;;
+    esac
+    shift
+done
+
+test $# -eq 0 || usage "Wrong number of arguements"
+
+# Get a list of all views
+stdout=$(aws athena start-query-execution --query-execution-context Database=$DATABASE \
+        --result-configuration "OutputLocation=$S3" \
+        --query-string "show views" )
+qid=$(echo $stdout | jq -r '.QueryExecutionId')
+
+# N.B. all these queries complete "instantly",
+#      this is not Athena best practice
+
+# get and display results
+aws s3 cp ${S3}${qid}.txt .
+cat $qid.txt
+
+# get or update queries
+for query in $(cat $qid.txt); do
+    stdout=$(aws athena start-query-execution --query-execution-context Database=$DATABASE \
+          --result-configuration "OutputLocation=$S3" \
+          --query-string "show create view \"$query\"" )
+    sqlqid=$(echo $stdout | jq -r '.QueryExecutionId')
+    aws s3 cp ${S3}${sqlqid}.txt $query.sql
+done


### PR DESCRIPTION
Fixes GH-89

Use AWS commands to get list of all active views, then export them. Note
that deleted views in Athena will not be deleted from the backup.