### PR TITLE
Add "raw" file support

### DIFF
--- a/metrics/metadata/collectors/metadata.py
+++ b/metrics/metadata/collectors/metadata.py
@@ -20,12 +20,12 @@ def get_args():
     parser = argparse.ArgumentParser(description=__doc__)
 
     parser.add_argument('-s', '--source-dir',
-                        default='.',
-                        help='source directory')
+			default='.',
+			help='source directory')
     
     parser.add_argument('-d', '--dest-dir',
 						default='.',
-                        help='destination directory')
+			help='destination directory')
     
     return parser.parse_args()
 
@@ -36,6 +36,7 @@ def main():
 	services_file = open(args.dest_dir + '/metadata_services.json','w')
 	urls_file = open(args.dest_dir + '/metadata_urls.json','w')
 	repos_file = open(args.dest_dir + '/metadata_repos.json','w')
+	raw_file = open(args.dest_dir + '/metadata.json','w')
 	
 	for filename in os.listdir(args.source_dir):
 		if filename.endswith(".json"): 
@@ -77,9 +78,13 @@ def main():
 					
 					repos_file.write(json.dumps(data) + '\n')
 
+			# Raw
+			raw_file.write(json.dumps(service_json) + '\n')
+
 	services_file.close()
 	urls_file.close()
 	repos_file.close()
+	raw_file.close()
 
 
 if __name__ == '__main__':

--- a/metrics/metadata/collectors/metadata_wrapper.sh
+++ b/metrics/metadata/collectors/metadata_wrapper.sh
@@ -14,3 +14,4 @@ python3 collectors/metadata.py -s foxsec/services/metadata -d out/
 aws s3 cp out/metadata_services.json s3://foxsec-metrics/metadata/metadata_services_json/metadata_services.json
 aws s3 cp out/metadata_urls.json s3://foxsec-metrics/metadata/metadata_urls_json/metadata_urls.json
 aws s3 cp out/metadata_repos.json s3://foxsec-metrics/metadata/metadata_repos_json/metadata_repos.json
+aws s3 cp out/metadata.json s3://foxsec-metrics/metadata/raw/metadata.json


### PR DESCRIPTION
Fixes #97

Write an "Athena compatible" JSON file that contains all the metadata
information.
    - Athena compatible means one JSON object" per line

metadata.py file uses tabs for indent. Fixed the few lines that used
spaces.